### PR TITLE
Add Docker support for zero-install local deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Dependencies and build output — rebuilt inside the container
+node_modules
+.next
+
+# Runtime data — provided via volume at deploy time
+data/
+
+# Git and tooling
+.git
+.gitignore
+.github
+
+# Local env files — secrets must never bake into the image
+.env
+.env.*
+.dev.vars
+.dev.vars.*
+
+# Editor / OS noise
+.DS_Store
+*.log

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# Copy to .env and fill in real values before running docker compose.
+
+RUNTIME=node
+
+# The email allowed to register the first owner account.
+OWNER_EMAIL=you@example.com
+
+# Long random secret for signing auth sessions.
+# Generate: openssl rand -base64 32
+# IMPORTANT: the app refuses to start if this is still the example value
+# while BETTER_AUTH_URL is set.  You MUST change this.
+BETTER_AUTH_SECRET=REPLACE_ME_openssl_rand_-base64_32
+
+# Must match the URL you access the app at (including port).
+BETTER_AUTH_URL=http://localhost:3000
+
+# Paths inside the container — these must point into /app/data so they land
+# on the persistent volume.  Do not change these unless you also update the
+# compose volume mount.
+SQLITE_DB_PATH=/app/data/seeder.db
+UPLOADS_DIR=/app/data/uploads
+
+# Optional ───────────────────────────────────────────────────────────────────
+
+# Extra origins allowed to make auth requests (comma-separated).
+# BETTER_AUTH_TRUSTED_ORIGINS=
+
+# Google OAuth (both required to enable Google sign-in).
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# Allowed origins for the MCP endpoint (/api/mcp).
+# Leave unset to permit any origin (auth token still required).
+# MCP_ALLOWED_ORIGINS=

--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,6 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-.env*
-
 # vercel
 .vercel
 
@@ -59,8 +56,6 @@ next-env.d.ts
 # BETTER_AUTH_SECRET; .env* is already ignored above.
 ecosystem.config.cjs
 seeder.service
-Dockerfile
-docker-compose.yml
 Caddyfile
 DEPLOY-node.md
 /data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,14 @@ RUN bun install --production
 # compiles the Next.js standalone output, and bundles the migration script to
 # plain JS so the runtime stage needs no TypeScript tooling.
 #
+# Pinned to $BUILDPLATFORM so the heavy Next.js compile always runs natively
+# on the build host (e.g. arm64 on Apple Silicon) regardless of the target
+# platform.  The output is pure JS — not architecture-specific.
+#
 # Uses bun: bun.lock is the authoritative lockfile (package-lock.json is
 # stale and missing transitive deps such as esbuild).
 # ──────────────────────────────────────────────
-FROM oven/bun:1 AS builder
+FROM --platform=$BUILDPLATFORM oven/bun:1 AS builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,94 @@
+# syntax=docker/dockerfile:1
+
+# ──────────────────────────────────────────────
+# Stage 1: prod-deps
+# Production-only install (no devDependencies).  Copied into the runtime
+# image to guarantee native packages like @libsql/client are present —
+# the Next.js standalone trace does not reliably follow native .node binaries.
+#
+# bun.lock is intentionally NOT copied here: the lockfile was generated on
+# macOS and bun on Linux wants to add Linux-specific optional packages,
+# which it treats as a lockfile violation.  A fresh resolution from
+# package.json alone is fine — bun resolves to the same versions because
+# package.json already pins exact or tight ranges, and no lockfile means
+# no frozen-lockfile enforcement.
+# ──────────────────────────────────────────────
+FROM oven/bun:1 AS prod-deps
+
+WORKDIR /app
+COPY package.json ./
+RUN bun install --production
+
+# ──────────────────────────────────────────────
+# Stage 2: builder
+# Full toolchain: installs all deps (including devDeps needed by the build),
+# compiles the Next.js standalone output, and bundles the migration script to
+# plain JS so the runtime stage needs no TypeScript tooling.
+#
+# Uses bun: bun.lock is the authoritative lockfile (package-lock.json is
+# stale and missing transitive deps such as esbuild).
+# ──────────────────────────────────────────────
+FROM oven/bun:1 AS builder
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install
+
+COPY . .
+
+# RUNTIME=node activates output:standalone in next.config.ts and swaps in
+# the libSQL / local-disk adapters.
+RUN RUNTIME=node bunx next build --webpack
+
+# Bundle the TypeScript migration script to a single CommonJS file.
+# @libsql/client is left external — it's a native module supplied by the
+# prod-deps stage rather than bundled.
+RUN bunx esbuild scripts/migrate-node.ts \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --external:@libsql/client \
+      --outfile=.next/standalone/migrate.js
+
+# ──────────────────────────────────────────────
+# Stage 3: runtime
+# Minimal image — no bun, no npm, no build toolchain.
+# ──────────────────────────────────────────────
+FROM node:20-slim AS runtime
+
+ENV RUNTIME=node \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0 \
+    NODE_ENV=production
+
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 seeder && \
+    adduser  --system --uid 1001 --ingroup seeder seeder
+
+# Standalone server bundle (includes its own minimal traced node_modules).
+COPY --from=builder --chown=seeder:seeder /app/.next/standalone ./
+# Overlay the full production node_modules so native packages (@libsql/client
+# and its Rust-compiled binaries) are guaranteed to be present regardless of
+# what the standalone tracer picked up.
+COPY --from=prod-deps --chown=seeder:seeder /app/node_modules   ./node_modules
+# Static assets and public dir must live alongside the standalone server.
+COPY --from=builder --chown=seeder:seeder /app/.next/static ./.next/static
+COPY --from=builder --chown=seeder:seeder /app/public        ./public
+# Raw SQL migration files read at runtime by migrate.js.
+COPY --from=builder --chown=seeder:seeder /app/migrations    ./migrations
+
+COPY --chown=seeder:seeder docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+RUN mkdir -p /app/data && chown seeder:seeder /app/data
+
+USER seeder
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:3000/', r => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))"
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ ENV RUNTIME=node \
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 1001 seeder && \
     adduser  --system --uid 1001 --ingroup seeder seeder
 
@@ -88,8 +90,9 @@ RUN chmod +x /entrypoint.sh
 
 RUN mkdir -p /app/data && chown seeder:seeder /app/data
 
-USER seeder
-
+# Entrypoint runs as root so it can fix /app/data ownership if the host
+# volume was created as root:root (common on Linux).  It drops to seeder
+# via gosu before running migrations or the server.
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: seeder:local
+    image: mrtimothyduong/seeder:latest
     # SQLite is single-writer — do not scale this service.
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: mrtimothyduong/seeder:latest
+    image: ghcr.io/danielsyauqi/seeder:latest
     # SQLite is single-writer — do not scale this service.
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  seeder:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: seeder:local
+    # SQLite is single-writer — do not scale this service.
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    volumes:
+      # Named volume keeps the SQLite DB and uploads across restarts.
+      - seeder_data:/app/data
+    healthcheck:
+      test: ["CMD", "node", "-e",
+             "require('http').get('http://localhost:3000/', r => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+volumes:
+  seeder_data:
+    # Local named volume — do NOT switch this to NFS/network FS.
+    # SQLite file locking breaks over network filesystems.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,29 @@
+# Docker Quick Start
+
+## 1. Configure
+
+```sh
+cp .env.example .env
+```
+
+Edit `.env` — set at minimum:
+- `OWNER_EMAIL` — your email (first sign-in creates the owner account)
+- `BETTER_AUTH_SECRET` — `openssl rand -base64 32`
+
+## 2. Build & run
+
+```sh
+docker compose build
+docker compose up -d
+```
+
+Migrations run automatically. Open `http://localhost:3000/sign-in`.
+
+## 3. Day-to-day
+
+```sh
+docker compose down       # stop (data survives)
+docker compose up -d      # start
+docker compose logs -f    # tail logs
+docker compose down -v    # wipe data (irreversible)
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,10 +10,10 @@ Edit `.env` — set at minimum:
 - `OWNER_EMAIL` — your email (first sign-in creates the owner account)
 - `BETTER_AUTH_SECRET` — `openssl rand -base64 32`
 
-## 2. Build & run
+## 2. Run (pre-built image from Docker Hub)
 
 ```sh
-docker compose build
+docker compose pull
 docker compose up -d
 ```
 
@@ -27,3 +27,26 @@ docker compose up -d      # start
 docker compose logs -f    # tail logs
 docker compose down -v    # wipe data (irreversible)
 ```
+
+---
+
+## Building & publishing (maintainer)
+
+Requires Docker Desktop with buildx. One-time builder setup:
+
+```sh
+docker buildx create --use --name multiarch --driver docker-container --bootstrap
+```
+
+Build and push multi-arch image (amd64 + arm64):
+
+```sh
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag mrtimothyduong/seeder:latest \
+  --push \
+  .
+```
+
+The builder stage runs natively on the host arch (arm64 on Apple Silicon) for
+both targets — only the lightweight prod-deps stage emulates amd64.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running migrations…"
+node /app/migrate.js
+
+echo "Starting server…"
+exec node /app/server.js

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 set -e
 
+# Fix ownership of the data directory in case the host volume was created as
+# root:root (common on Linux when the Docker daemon creates the named volume).
+chown seeder:seeder /app/data
+
 echo "Running migrations…"
-node /app/migrate.js
+gosu seeder node /app/migrate.js
 
 echo "Starting server…"
-exec node /app/server.js
+exec gosu seeder node /app/server.js

--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,10 @@ const nextConfig: NextConfig = {
   // bundled into the Workers build — keep it external. (It's also on Next's
   // built-in auto-externalise list; this is belt-and-braces.)
   serverExternalPackages: ["@libsql/client"],
+  // Standalone output traces dependencies and produces a self-contained
+  // server.js — essential for a lean Docker runtime image. Only applied in
+  // node mode; the Cloudflare build uses opennextjs-cloudflare instead.
+  ...(process.env.RUNTIME === "node" ? { output: "standalone" } : {}),
   async headers() {
     return [{ source: "/:path*", headers: securityHeaders }];
   },


### PR DESCRIPTION
PR in regards enabling Docker deployment method for `Seeder`. 

## Caveats:
* The docker-compose.yaml needs to be updated/changed to the respective image deployment method that you choose @danielsyauqi . E.g. dockerhub or ghcr.io. `image: danielsyauqi/seeder:latest`
* Current state of the build leaves the image size @ ~500MB due to the bun/npm dependencies
* Performing a build from underpowered system (tested with 2core/4GB VM), I was able to `buildx` on Base-M4 mini for AMD64+ARM architectures.

### Changes

8cf70b3 — Docker support (multi-stage bun/node build)
- Adds Dockerfile, docker-compose.yml, .dockerignore, .env.example, and docker/entrypoint.sh
- Multi-stage image: Bun for build, Node for runtime — keeps the production image lean
- Database migrations run automatically on first container start
- Fixes next.config.ts to emit standalone output when RUNTIME=node (required for the image)

387a932 — Multi-arch buildx support + Docker Hub image
- Builder stage pinned to $BUILDPLATFORM so the Next.js compile runs natively (fast on Apple Silicon)
- Only the prod-deps stage emulates amd64, making cross-platform builds significantly faster
- docker-compose.yml now references mrtimothyduong/seeder:latest so downstream machines can docker compose pull instead of building locally

923c4f6 — Fix root-owned volumes on Linux hosts
- On Linux, Docker can create named volumes as root:root before the image's file ownership takes effect, causing SQLITE_CANTOPEN for the non-root seeder user
- Installs gosu in the runtime image; entrypoint runs as root, chowns /app/data, then drops to seeder via gosu before starting migrations and the server
- PID 1 remains non-root with correct signal handling

### Usage
cp .env.example .env # fill in secrets
docker compose up