### PR TITLE
fix(board): stop kanban flicker below 1280px

### DIFF
--- a/app/(app)/projects/[projectId]/page.tsx
+++ b/app/(app)/projects/[projectId]/page.tsx
@@ -44,11 +44,12 @@ export default async function ProjectOverviewPage({
     >
       <ProjectMetricsStrip workspace={workspace} />
 
-      {/* minmax(0,…) is required: the board's flex track uses a percent-based
-          flex-basis on shrink-0 columns. A bare `1.45fr` track gives the grid
-          item `min-width:auto`, which lets that percentage run away to the
-          browser's max width. minmax(0,…) pins the min to 0 and breaks the loop. */}
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(0,0.55fr)]">
+      {/* minmax(0,…) is required at every breakpoint: the board's flex track
+          uses a percent-based flex-basis on shrink-0 columns. An implicit `auto`
+          track or a bare `fr` track gives the grid item `min-width:auto`, which
+          pins the item to the board's 872px min-content and lets that percentage
+          run away. minmax(0,…) holds the min at 0 and breaks the loop. */}
+      <div className="grid grid-cols-[minmax(0,1fr)] gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(0,0.55fr)]">
         <ProjectBoardSurface workspace={workspace} currentPath={currentPath} preview />
         <ProjectNotesSurface workspace={workspace} currentPath={currentPath} />
       </div>


### PR DESCRIPTION
## Issue

The kanban board on the project overview flickers when the viewport is less than approximately 1240px.

<details>
<summary>Technical explanation</summary>

The grid that holds the board set `minmax(0,…)` column templates only at the `xl` breakpoint (1280px). Below that width, the grid used one implicit `auto` track. An `auto` track gives the grid item `min-width: auto`, which resolves to min-content.

The board's min-content is 872px, because the columns are `shrink-0` on their `17.5rem` floor:

```
3 × 280px columns + 2 × 16px gaps = 872px
```

At a 1238px viewport the panel has approximately 915px available and needs 920px. The panel therefore took its min-content width and overflowed `main`. The percent-based `flex-basis` in `kanban-board.tsx` then resolved against the oversized track. The `ResizeObserver` in `BoardScroll` measured that track and toggled the proxy scrollbar above the board. Each toggle added or removed 20px of height, which forced a new layout pass and flipped the measurement again.

Frames from a screen recording, 33ms apart, alternate between two states:

| | panel width | proxy scrollbar |
|---|---|---|
| A | ~790px | hidden |
| B | ~920px | shown, columns 20px lower |

</details>


https://github.com/user-attachments/assets/dc1bf7b1-4498-4220-bff1-e8b4912c659f



## Fix

Add a base `grid-cols-[minmax(0,1fr)]` template, so the guard applies at every breakpoint.

The panel then measures 915px against 915px available, and the observer settles after one pass.

## Notes

- The board tab (`board/page.tsx`) has no grid wrapper. Only the overview showed the fault.
- The second grid on the same page keeps its `xl`-only template. Its content has no large min-content today.
- `npx tsc --noEmit` passes.
